### PR TITLE
[fix] correct URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# grunt-contrib-obfuscator [![Build Status](https://travis-ci.org/javascript-obfuscator/grunt-contrib-obfuscator.svg?branch=master)](https://travis-ci.org/javascript-obfuscator/grunt-contrib-obfuscator)
+# grunt-contrib-obfuscator [![Build Status](https://travis-ci.com/javascript-obfuscator/grunt-contrib-obfuscator.svg?branch=master)](https://travis-ci.com/javascript-obfuscator/grunt-contrib-obfuscator)
 
 > Obfuscate JavaScript files using [javascript-obfuscator](https://github.com/javascript-obfuscator/javascript-obfuscator)@0.10.0.
 
-You can try the javascript-obfuscator module and see all its options here: https://javascriptobfuscator.herokuapp.com
+You can try the javascript-obfuscator module and see all its options here: https://obfuscator.io/
 
 ## Getting Started
 


### PR DESCRIPTION
Current Travis link leads to URL redirect page:
![image](https://user-images.githubusercontent.com/16267156/72801429-87208500-3c5a-11ea-9b1f-9f84537995ff.png)
Now it's pointing to correct location.
A link to test page also updated.