### PR TITLE
Use newer versions of NodeJS and javascript-obfuscator 0.23.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ sudo: false
 language: node_js
 
 node_js:
-  - "4"
-  - "5"
-  - "6"
+  - "10"
+  - "12"
+  - "13"
+  - "stable"
 
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grunt-contrib-obfuscator [![Build Status](https://travis-ci.org/javascript-obfuscator/grunt-contrib-obfuscator.svg?branch=master)](https://travis-ci.org/javascript-obfuscator/grunt-contrib-obfuscator)
 
-> Obfuscate JavaScript files using [javascript-obfuscator](https://github.com/javascript-obfuscator/javascript-obfuscator)@0.10.0.
+> Obfuscate JavaScript files using [javascript-obfuscator](https://github.com/javascript-obfuscator/javascript-obfuscator)@0.23.2.
 
 You can try the javascript-obfuscator module and see all its options here: https://javascriptobfuscator.herokuapp.com
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "chalk": "^1.0.0",
-    "javascript-obfuscator": "^0.10.0"
+    "javascript-obfuscator": "^0.23.2"
   },
   "devDependencies": {
     "grunt": "^1.0.0",


### PR DESCRIPTION
The list of versions now matches the list from [javascript-obfuscator](https://github.com/javascript-obfuscator/javascript-obfuscator/blob/master/.travis.yml)