### PR TITLE
Update to 4.0 and automatically generate identifiersPrefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ _Note that at this time the `sourceMap` isn't implemented in this plugin._
 
 In addition to the obfuscator options, you can also use:
 
+#### baseIdentifiersPrefix
+Type: `String`
+Default: `'_'`
+
+This string will be used as a prefix for the identifiersPrefix values. It must not be numeric. The identifiersPrefix will be set to `'baseIdentifiersPrefix' + n` where 'n' is an auto-incrementing number.
+
+
 #### banner
 Type: `String`
 Default: `''`

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "chalk": "^1.0.0",
-    "javascript-obfuscator": "^2.0.0"
+    "javascript-obfuscator": "^4.0.0"
   },
   "devDependencies": {
     "grunt": "^1.0.0",
@@ -28,7 +28,7 @@
     "grunt-contrib-nodeunit": "^1.0.0"
   },
   "peerDependencies": {
-    "javascript-obfuscator": "^2.0.0"
+    "javascript-obfuscator": "^4.0.0"
   },
   "keywords": [
     "gruntplugin",

--- a/tasks/obfuscator.js
+++ b/tasks/obfuscator.js
@@ -53,13 +53,17 @@ module.exports = function (grunt) {
 
       var filenameDest = getFilename(file.dest);
 
+      var execOptions = Object.assign({
+          identifiersPrefix: (options.baseIdentifiersPrefix || '_') + created.files
+      }, options);
+
       if (filenameDest) {
         try {
           var totalCode = availableFiles.map(function (file) {
               return grunt.file.read(file);
           }).join('');
 
-          obfuscated = obfuscate(totalCode, options);
+          obfuscated = obfuscate(totalCode, execOptions);
 
         } catch (err) {
           grunt.log.error(err);
@@ -76,7 +80,7 @@ module.exports = function (grunt) {
           try {
             var code = grunt.file.read(fileSrc);
 
-            obfuscated = obfuscate(code, options);
+            obfuscated = obfuscate(code, execOptions);
 
           } catch (err) {
             grunt.log.error(err);


### PR DESCRIPTION
Generation of identifiersPrefix values per file is required as requested here already https://github.com/javascript-obfuscator/grunt-contrib-obfuscator/issues/20


to avoid errors like these:

- https://github.com/javascript-obfuscator/javascript-obfuscator/issues/568
- https://github.com/javascript-obfuscator/javascript-obfuscator/issues/1093
- https://github.com/javascript-obfuscator/javascript-obfuscator/issues/1150
- https://github.com/javascript-obfuscator/javascript-obfuscator/issues/1172

